### PR TITLE
Update README instructions to delete tmp directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,16 @@ run the description generation, `[d]escription`.
 
 ## Post-Processing
 
+To ensure the correct media file is generated each week, it is essential to delete the `tmp` directory after the current media file has been successfully created. If the `tmp` directory is not deleted, next week’s media file will use the previous week’s data instead of generating a new file.
+
+Delete the `tmp` directory by either:
+- Manually deleting the folder
+- Running the command `rm -r tmp` in your terminal
+
+
 Once the automated processing is complete, the final media file will be saved to
 `data/` by default, or the specified data directory on your host machine.
 Afterwards, follow the manual steps that print in the console.
-
-Delete the `tmp` folder by either:
-- Manually deleting the folder
-- Running the command `rm -r tmp`
 
 ## Deactivating Docker Container
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Once the automated processing is complete, the final media file will be saved to
 `data/` by default, or the specified data directory on your host machine.
 Afterwards, follow the manual steps that print in the console.
 
+Delete the `tmp` folder by either:
+- Manually deleting the folder
+- Running the command `rm -r tmp`
+
 ## Deactivating Docker Container
 
 When you're done, the Docker container will automatically stop as we've used the


### PR DESCRIPTION
## Description

Updated README to include instructions for deleting the `tmp` directory.
By not doing so before scrubbing a new audio file, a previous sermon audio file will be created.

**NOTE:**
This is just a temporary placement until an actual fix is implemented.

<img width="1573" alt="Screenshot 2024-05-27 at 1 02 51 PM" src="https://github.com/metrophilly/sermon-processor/assets/59262348/dbc5e322-f50f-4969-a4c7-5df8c8a3b5bd">



